### PR TITLE
Custom command to set users inactive

### DIFF
--- a/BioForm/profiles/management/commands/setuserinactive.py
+++ b/BioForm/profiles/management/commands/setuserinactive.py
@@ -7,16 +7,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         days_offline = 10
 
-        inactive_users = Account.objects.filter(last_login__lte=datetime.now()-timedelta(days=days_offline))
-
-        if inactive_users:
-            for user in inactive_users:
-                
-                count += 1
-                user.is_active = False
-
-                user.save()
+        inactive_users_queryset = Account.objects.filter(last_login__lte=datetime.now()-timedelta(days=days_offline))
+        inactive_users_count = inactive_users_queryset.count()
+        inactive_users_queryset.update(is_active=False)
         
-        print(f"{count} user(s) were set to inactive")
-
-
+        print(f"{inactive_users_count} user(s) were set to inactive")

--- a/BioForm/profiles/management/commands/setuserinactive.py
+++ b/BioForm/profiles/management/commands/setuserinactive.py
@@ -5,14 +5,19 @@ from datetime import date
 class Command(BaseCommand):
 
     def handle(self, *args, **options):
+        count = 0
         active_users = Account.objects.filter(is_active=True)
 
         if active_users:
             for user in active_users:
                 date_difference = date.today() - user.last_login.date()
-                print(date_difference.days)
+
                 if date_difference.days >=10 and user.is_admin == False:
+                    count += 1
                     user.is_active = False
+
                     user.save()
+        
+        print(f"{count} user(s) were set to inactive")
 
 

--- a/BioForm/profiles/management/commands/setuserinactive.py
+++ b/BioForm/profiles/management/commands/setuserinactive.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from profiles.models import Account
+from datetime import date
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        active_users = Account.objects.filter(is_active=True)
+
+        if active_users:
+            for user in active_users:
+                date_difference = date.today() - user.last_login.date()
+                print(date_difference.days)
+                if date_difference.days >=10 and user.is_admin == False:
+                    user.is_active = False
+                    user.save()
+
+

--- a/BioForm/profiles/management/commands/setuserinactive.py
+++ b/BioForm/profiles/management/commands/setuserinactive.py
@@ -1,22 +1,21 @@
 from django.core.management.base import BaseCommand
 from profiles.models import Account
-from datetime import date
+from datetime import datetime, timedelta
 
 class Command(BaseCommand):
 
     def handle(self, *args, **options):
-        count = 0
-        active_users = Account.objects.filter(is_active=True)
+        days_offline = 10
 
-        if active_users:
-            for user in active_users:
-                date_difference = date.today() - user.last_login.date()
+        inactive_users = Account.objects.filter(last_login__lte=datetime.now()-timedelta(days=days_offline))
 
-                if date_difference.days >=10 and user.is_admin == False:
-                    count += 1
-                    user.is_active = False
+        if inactive_users:
+            for user in inactive_users:
+                
+                count += 1
+                user.is_active = False
 
-                    user.save()
+                user.save()
         
         print(f"{count} user(s) were set to inactive")
 


### PR DESCRIPTION
A custom command was made called "setuserinactive" which checks if the last login time for a user is 10 days or more. If it is, the command sets the "is_active" field to false, deactivating the user. 

Since I did not have any users that had logged in 10 days ago, I changed the days check to 1 and the code ran as it should have.

Feedback:
Feedback is currently being given in a print statement as logging creates another file which seems unnecessary. Upon review, the mechanism for feedback will be changed as per requested.
<img width="511" alt="image" src="https://user-images.githubusercontent.com/110596170/189305470-854a0b62-d4cc-40d3-af78-3ba3823647fe.png">


Note: - The way to run this command is "python manage.py setuserinactive". 
          - User's that have admin privileges (superusers) will not be affected by this command.